### PR TITLE
Mark as GraphQL 3.x compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "type": "silverstripe-vendormodule",
     "require": {
         "silverstripe/framework": "^4.0",
-        "silverstripe/graphql": "^1.0 || ^2.0",
+        "silverstripe/graphql": "^1.0 || ^2.0 || ^3.0",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
The two integration tests fail, and I'm not sure how to get them working again. See attempt below. Actually, I don't know how they ever worked without further configuration :D I've tested the GraphQL operation manually on `4.3.x-dev` and it still works.

The integration tests need to have the `/graphql` endpoint and route configured, with at least one valid query and type in there. Which I've managed to do, but they're now causing issues with types being defined twice: Once through `SapphireTest->setUpOnce()` which calls `GraphQL\Controller->flush()` (and consequently `Manager->configure()`), and then in the same in-memory state through the actual `GraphQL\Controller->index()`. I'm not sure that's worth fixing right now, because @unclecheese is restructuring the whole way on how the schema is created, and it's only the tests which are broken, not the functionality.

```diff
diff --git a/tests/unit/GraphQL/ApiKeyAuthenticatorTest.php b/tests/unit/GraphQL/ApiKeyAuthenticatorTest.php
index 56c58ce..cd4596e 100644
--- a/tests/unit/GraphQL/ApiKeyAuthenticatorTest.php
+++ b/tests/unit/GraphQL/ApiKeyAuthenticatorTest.php
@@ -3,6 +3,8 @@
 namespace Sminnee\ApiKey\Tests\GraphQL;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\Security\Member;
 use Sminnee\ApiKey\MemberApiKey;
 use SilverStripe\Control\HTTPRequest;
@@ -48,6 +50,9 @@ class ApiKeyAuthenticatorTest extends SapphireTest
     protected function setUp()
     {
         parent::setUp();
+
+        Config::nest();
+
         $this->member = $this->objFromFixture(Member::class, 'admin');
         $this->key = MemberApiKey::createKey($this->member->ID);
         $this->headerName = Config::inst()->get(ApiKeyRequestMiddlware::class, 'header_name');
@@ -57,6 +62,31 @@ class ApiKeyAuthenticatorTest extends SapphireTest
                 'priority' => 30,
             ],
         ];
+
+        // Required for integration testing
+        $schemas = Manager::config()->get('schemas');
+        $schemas['default'] = [
+            'scaffolding' => [
+                'types' => [
+                    Member::class => [
+                        'fields' => ['ID']
+                    ]
+                ]
+            ]
+        ];
+        Manager::config()->update('schemas', $schemas);
+
+        // Required for integration testing
+        $rules = Director::config()->get('rules');
+        $rules['graphql'] = '%$SilverStripe\GraphQL\Controller.default';
+        Director::config()->update('rules', $rules);
+    }
+
+    protected function tearDown()
+    {
+        Config::unnest();
+
+        parent::tearDown();
     }
 
     public function testNoKey()
@@ -125,13 +155,14 @@ class ApiKeyAuthenticatorTest extends SapphireTest
         // No key supplied
         $request = new HTTPRequest('POST', Director::absoluteBaseURL() . '/graphql');
 
+        StaticSchema::reset();
         $response = Director::test(
             '/graphql',
             [],
             [],
             'POST',
-            '',
-            [],
+            json_encode(['query' => 'query IntrospectionQuery { __schema { queryType { name } } }']),
+            ['Content-Type' => 'application/json'],
             [],
             $request
         );
@@ -147,14 +178,16 @@ class ApiKeyAuthenticatorTest extends SapphireTest
         // Successful Authentication but no Authorisation
         $request = new HTTPRequest('POST', Director::absoluteBaseURL() . '/graphql');
 
+        StaticSchema::reset();
         $response = Director::test(
             '/graphql',
             [],
             [],
             'POST',
-            '',
+            json_encode(['query' => 'query IntrospectionQuery { __schema { queryType { name } } }']),
             [
                 $this->headerName => $this->key->ApiKey,
+                'Content-Type' => 'application/json'
             ],
             [],
             $request

```