### PR TITLE
fix typo and tests

### DIFF
--- a/src/GraphQL/ApiKeyAuthenticator.php
+++ b/src/GraphQL/ApiKeyAuthenticator.php
@@ -7,7 +7,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\GraphQL\Auth\AuthenticatorInterface;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Security\Member;
-use Sminnee\ApiKey\ApiKeyRequestMiddlware;
+use Sminnee\ApiKey\ApiKeyRequestMiddleware;
 use Sminnee\ApiKey\MemberApiKey;
 
 /**
@@ -52,7 +52,7 @@ class ApiKeyAuthenticator implements AuthenticatorInterface
      */
     protected function getApiKeyHeader(HTTPRequest $request)
     {
-        $headerName = Config::inst()->get(ApiKeyRequestMiddlware::class, 'header_name');
+        $headerName = Config::inst()->get(ApiKeyRequestMiddleware::class, 'header_name');
 
         return $request->getHeader($headerName) ?: false;
     }

--- a/tests/unit/GraphQL/ApiKeyAuthenticatorTest.php
+++ b/tests/unit/GraphQL/ApiKeyAuthenticatorTest.php
@@ -11,7 +11,7 @@ use Sminnee\ApiKey\GraphQL\ApiKeyAuthenticator;
 use SilverStripe\GraphQL\Auth\Handler;
 use Sminnee\ApiKey\ApiKeyMemberExtension;
 use SilverStripe\Core\Config\Config;
-use Sminnee\ApiKey\ApiKeyRequestMiddlware;
+use Sminnee\ApiKey\ApiKeyRequestMiddleware;
 use SilverStripe\ORM\ValidationException;
 
 class ApiKeyAuthenticatorTest extends SapphireTest
@@ -50,7 +50,7 @@ class ApiKeyAuthenticatorTest extends SapphireTest
         parent::setUp();
         $this->member = $this->objFromFixture(Member::class, 'admin');
         $this->key = MemberApiKey::createKey($this->member->ID);
-        $this->headerName = Config::inst()->get(ApiKeyRequestMiddlware::class, 'header_name');
+        $this->headerName = Config::inst()->get(ApiKeyRequestMiddleware::class, 'header_name');
         Handler::config()->authenticators = [
             [
                 'class' => ApiKeyAuthenticator::class,

--- a/tests/unit/MemberApiKeyTest.php
+++ b/tests/unit/MemberApiKeyTest.php
@@ -7,7 +7,6 @@ use SilverStripe\Security\Member;
 use Sminnee\ApiKey\MemberApiKey;
 use Sminnee\ApiKey\ApiKeyMemberExtension;
 use InvalidArgumentException;
-use SilverStripe\ORM\Connect\DatabaseException;
 use SilverStripe\ORM\FieldType\DBDatetime;
 
 class MemberApiKeyTest extends SapphireTest
@@ -69,7 +68,7 @@ class MemberApiKeyTest extends SapphireTest
         // should not be able to create a duplicate key
         $keyObject = MemberApiKey::create();
         $keyObject->ApiKey = 'fakey';
-        $this->expectException(DatabaseException::class);
+        $this->expectException("mysqli_sql_exception");
         $this->expectExceptionMessage(
             "Duplicate entry 'fakey'"
         );


### PR DESCRIPTION
Fixes most of the tests for SS5, except the GraphQL tests in which the `Director::test` response is "No URL rule was matched" instead of the `$response` it expects, but I'd have no idea where to start with GraphQL endpoints or what's changed there.